### PR TITLE
Emit JSON for providers

### DIFF
--- a/urbit/app/keep.hoon
+++ b/urbit/app/keep.hoon
@@ -97,9 +97,9 @@
 ::
 |%
 ++  website-card
-=,  enjs:format
   |=  [event=@t diff=json]
   ^-  card
+  =,  enjs:format
   :*  %give  %fact  ~[/website]  %json
       !>  %-  pairs
       :~  [%type s+event]
@@ -113,8 +113,8 @@
   ==  ==  ==
 ::
 ++  json-backup
-=,  enjs:format
   |=  [time=@da =dude =@p]
   ^-  json
+  =,  enjs:format
   (pairs ~[ship+(ship p) agent+s+dude time+(sect time)])
 --


### PR DESCRIPTION
The keep agent now emits updates whenever it stores a new backup. In this case the `type` field is `"backup"` and the `diff` field looks like this:

```json
{
  "ship": "~sampel-palnet",
  "agent": "gora",
  "time": 979873498273
}
```

Additionally, the `state` field that is always part of any emitted JSON now has one additional field, `backups`. It is an array containing several such objects.