### PR TITLE
Stateless wrapper

### DIFF
--- a/interface/src/App.vue
+++ b/interface/src/App.vue
@@ -1,57 +1,66 @@
 <template>
   <v-app class="tw-font-silom">
-    <v-app-bar extend color="primary">
-      <template v-slot:prepend>
-        <v-app-bar-nav-icon
-          @click="navDrawer = !navDrawer"
-        ></v-app-bar-nav-icon>
-      </template>
-
-      <v-app-bar-title>
-        <router-link :to="{ name: 'work' }">Keep</router-link>
-      </v-app-bar-title>
-
-      <template v-slot:append>
-        <a
-          href="https://quartus.co"
-          target="_blank"
-          style="position: relative; top: 25px"
-        >
-          <div style="position: relative">
-            <v-img :src="logo" contain height="75" width="75" />
-          </div>
-        </a>
-      </template>
-    </v-app-bar>
-
-    <v-navigation-drawer v-model="navDrawer" bottom temporary color="primary">
-      <v-list color="primary">
-        <v-list-item
-          color="info"
-          v-for="i in items"
-          :key="i.name"
-          :to="{ name: i.route }"
-        >
-          {{ i.name }}
-        </v-list-item>
-      </v-list>
-    </v-navigation-drawer>
-
-    <v-main class="tw-container tw-mx-auto tw-my-8">
-      <router-view></router-view>
-      <!--
-      <button @click="startMainAirlock">Start Main airlock(s)</button>
-      <button @click="closeMainAirlock">Close keep airlock</button>
-      <button @click="closeAgentAirlocks">Close all agent airlocks</button>
+    <div class="tw-flex tw-flex-row tw-justify-center tw-p-8">
       <div>
-        messages:
-        <ul>
-          <li v-for="m in messages" :key="m">{{ m }}</li>
-        </ul>
+        <h1 class="tw-text-2xl">
+        Coming soon. Check back in a few days
+        </h1>
       </div>
-      -->
-    </v-main>
-    <Message style="position: fixed; bottom: 0;" class="tw-fixed tw-bottom-0 tw-right-0 tw-w-full tw-p-2 tw-opacity-100 sm:tw-w-1/3"/>
+    </div>
+    <div v-if="false">
+      <v-app-bar extend color="primary">
+        <template v-slot:prepend>
+          <v-app-bar-nav-icon
+            @click="navDrawer = !navDrawer"
+          ></v-app-bar-nav-icon>
+        </template>
+
+        <v-app-bar-title>
+          <router-link :to="{ name: 'work' }">Keep</router-link>
+        </v-app-bar-title>
+
+        <template v-slot:append>
+          <a
+            href="https://quartus.co"
+            target="_blank"
+            style="position: relative; top: 25px"
+          >
+            <div style="position: relative">
+              <v-img :src="logo" contain height="75" width="75" />
+            </div>
+          </a>
+        </template>
+      </v-app-bar>
+
+      <v-navigation-drawer v-model="navDrawer" bottom temporary color="primary">
+        <v-list color="primary">
+          <v-list-item
+            color="info"
+            v-for="i in items"
+            :key="i.name"
+            :to="{ name: i.route }"
+          >
+            {{ i.name }}
+          </v-list-item>
+        </v-list>
+      </v-navigation-drawer>
+
+      <v-main class="tw-container tw-mx-auto tw-my-8">
+        <router-view></router-view>
+        <!--
+        <button @click="startMainAirlock">Start Main airlock(s)</button>
+        <button @click="closeMainAirlock">Close keep airlock</button>
+        <button @click="closeAgentAirlocks">Close all agent airlocks</button>
+        <div>
+          messages:
+          <ul>
+            <li v-for="m in messages" :key="m">{{ m }}</li>
+          </ul>
+        </div>
+        -->
+      </v-main>
+      <Message style="position: fixed; bottom: 0;" class="tw-fixed tw-bottom-0 tw-right-0 tw-w-full tw-p-2 tw-opacity-100 sm:tw-w-1/3"/>
+    </div>
   </v-app>
 </template>
 

--- a/interface/src/App.vue
+++ b/interface/src/App.vue
@@ -3,7 +3,10 @@
     <div class="tw-flex tw-flex-row tw-justify-center tw-p-8">
       <div>
         <h1 class="tw-text-2xl">
-        Coming soon. Check back in a few days
+        Coming soon. Check back in a few days.
+        </h1>
+        <h1 class="tw-text-2xl">
+        Learn more at <span class="tw-font-mono">~mister-hilper-dozzod-dalten/quartus</span>
         </h1>
       </div>
     </div>

--- a/urbit/app/keep.hoon
+++ b/urbit/app/keep.hoon
@@ -197,7 +197,7 @@
       :_  this
       ~[(emit no-save/(da:event:json &2.wire (of-wire |2.wire) now.bowl))]  
     :_  this(last (~(put bi last) &2.wire (of-wire |2.wire) now.bowl))
-    ~[(emit last/(da:event:json &2.wire (of-wire |2.wire) now.bowl))]
+    ~[(emit saved/(da:event:json &2.wire (of-wire |2.wire) now.bowl))]
   ::
       [%backups term term ~]
     ~|  %not-whitelisted

--- a/urbit/app/keep.hoon
+++ b/urbit/app/keep.hoon
@@ -290,9 +290,9 @@
       |=  [dap=dude place=(unit @p) freq=(unit @dr)]
       ^-  ^json
       %-  pairs
-      :~  ['app' s/dap]
-          ['ship' (bindcast place ship)]
-          ['freq' (bindcast freq (corl numb (curr div ~s1)))]
+      :~  [%agent s/dap]
+          [%ship (bindcast place ship)]
+          [%freq (bindcast freq (corl numb (curr div ~s1)))]
       ==
     ::
     ++  ok

--- a/urbit/app/keep.hoon
+++ b/urbit/app/keep.hoon
@@ -131,7 +131,6 @@
     =/  behn  ~(. pass:io behn/dap.cmd^(path-of to.cmd))
     :~  (bind (both prev freq) (cork add rest:behn))  :: unset old next
         `(emit auto/(dr:event:json dap.cmd to.cmd freq.cmd))
-        ::TODO emit json  `(~(auto json state) dap.cmd to.cmd freq.cmd)
         ?^  new=(bind (both prev freq.cmd) (cork add wait:behn))
           new  ::  set next later
         (bind freq.cmd |=(* (wait:behn now.bowl)))  :: set next now
@@ -194,10 +193,11 @@
   ::
       [%send term ^]
     ?.  ?=(%poke-ack -.sign)  (on-agent:def wire sign)
-    ?~  p.sign
-      `this(last (~(put bi last) &2.wire (of-wire |2.wire) now.bowl))
-    :_  this
-    ~[(emit no-save/(da:event:json &2.wire (of-wire |2.wire) now.bowl))]  
+    ?^  p.sign
+      :_  this
+      ~[(emit no-save/(da:event:json &2.wire (of-wire |2.wire) now.bowl))]  
+    :_  this(last (~(put bi last) &2.wire (of-wire |2.wire) now.bowl))
+    ~[(emit last/(da:event:json &2.wire (of-wire |2.wire) now.bowl))]
   ::
       [%backups term term ~]
     ~|  %not-whitelisted

--- a/urbit/app/keep.hoon
+++ b/urbit/app/keep.hoon
@@ -196,7 +196,7 @@
     ?^  p.sign
       :_  this
       ~[(emit no-save/(da:event:json &2.wire (of-wire |2.wire) now.bowl))]  
-    =.  last  (~(put bi last) &2.wire (of-wire |2.wire) now.bowl))
+    =.  last  (~(put bi last) &2.wire (of-wire |2.wire) now.bowl)
     :_  this
     ~[(emit saved/(da:event:json &2.wire (of-wire |2.wire) now.bowl))]
   ::

--- a/urbit/app/keep.hoon
+++ b/urbit/app/keep.hoon
@@ -196,7 +196,8 @@
     ?^  p.sign
       :_  this
       ~[(emit no-save/(da:event:json &2.wire (of-wire |2.wire) now.bowl))]  
-    :_  this(last (~(put bi last) &2.wire (of-wire |2.wire) now.bowl))
+    =.  last  (~(put bi last) &2.wire (of-wire |2.wire) now.bowl))
+    :_  this
     ~[(emit saved/(da:event:json &2.wire (of-wire |2.wire) now.bowl))]
   ::
       [%backups term term ~]

--- a/urbit/app/keep.hoon
+++ b/urbit/app/keep.hoon
@@ -194,8 +194,10 @@
   ::
       [%send term ^]
     ?.  ?=(%poke-ack -.sign)  (on-agent:def wire sign)
-    ?^  p.sign                (on-agent:def wire sign)
-    `this(last (~(put bi last) &2.wire (of-wire |2.wire) now.bowl))
+    ?~  p.sign
+      `this(last (~(put bi last) &2.wire (of-wire |2.wire) now.bowl))
+    :_  this
+    ~[(emit no-save/(da:event:json &2.wire (of-wire |2.wire) now.bowl))]  
   ::
       [%backups term term ~]
     ~|  %not-whitelisted
@@ -252,7 +254,6 @@
     ^-  card
     %-  fact:agentio  :_  ~[/website]
     :-  %json  !>  ^-  ^json
-    =-  ~&  >  emit/-  -
     %-  pairs 
     :~  [%type s+type]
         [%diff diff]
@@ -281,9 +282,9 @@
   ++  event
     |%
     ++  da
-      |=  [dap=dude place=(unit @p) prev=@da]
+      |=  [dap=dude place=(unit @p) time=@da]
       ^-  ^json
-      (pairs ~[agent/s/dap ship/(bindcast place ship) time/(sect prev)])
+      (pairs ~[agent/s/dap ship/(bindcast place ship) time/(sect time)])
     ::
     ++  dr
       |=  [dap=dude place=(unit @p) freq=(unit @dr)]

--- a/urbit/app/keep.hoon
+++ b/urbit/app/keep.hoon
@@ -21,7 +21,7 @@
         able=(each (set ship) (set ship))
         into=(set desk)
         auto=(mip dude (unit ship) @dr)
-        last=(mip dude (unit ship) @da)
+        last=(mip dude (unit ship) [sent=@da kept=(unit @da)])
     ==
   ::
   ++  path-of
@@ -108,7 +108,7 @@
       %once
     ?>  =(src.bowl our.bowl)
     =/  freq  (~(get bi auto) dap.cmd to.cmd)
-    =/  prev  (~(get bi last) dap.cmd to.cmd)
+    =/  prev  (bind (~(get bi last) dap.cmd to.cmd) head)
     =/  behn  ~(. pass:io behn/dap.cmd^(path-of to.cmd))
     :_  this
     %-  catunits
@@ -121,7 +121,7 @@
       %many
     ?>  =(src.bowl our.bowl)
     =/  freq  (~(get bi auto) dap.cmd to.cmd)
-    =/  prev  (~(get bi last) dap.cmd to.cmd)
+    =/  prev  (bind (~(get bi last) dap.cmd to.cmd) head)
     =.  auto
       ?~  freq.cmd
         (~(del bi auto) dap.cmd to.cmd)
@@ -138,15 +138,12 @@
   ::
   ::  Successful backup
       %okay
-    :_  this
-    :_  ~
-    %+  emit  %success
-    %:  ok:event:json
-      dap.cmd
-      src.bowl
+    =/  current
+      =-  -(kept `time.cmd)
       (~(got bi last) dap.cmd `src.bowl)
-      time.cmd
-    ==
+    =.  last  (~(put bi last) dap.cmd `src.bowl current)
+    :_  this
+    ~[(emit success/(ok:event:json dap.cmd `src.bowl current))]
   ::
   ::  "(De)whitelist this ship," said our operator.
       %able
@@ -196,7 +193,10 @@
     ?^  p.sign
       :_  this
       ~[(emit no-save/(da:event:json &2.wire (of-wire |2.wire) now.bowl))]  
-    =.  last  (~(put bi last) &2.wire (of-wire |2.wire) now.bowl)
+    =.  last
+      %^  ~(put bi last)  &2.wire  (of-wire |2.wire)
+      =-  -(sent now.bowl)
+      (~(gut bi last) &2.wire (of-wire |2.wire) [sent=now.bowl ~])
     :_  this
     ~[(emit saved/(da:event:json &2.wire (of-wire |2.wire) now.bowl))]
   ::
@@ -260,7 +260,7 @@
         [%diff diff]
         :-  %state
         %-  pairs
-        :~  [%saved a/(turn ~(tap bi last.state) da:event)]
+        :~  [%saved a/(turn ~(tap bi last.state) ok:event)]
             [%agents a/(turn ~(tap in live.state) (lead %s))]
             [%desks a/(turn ~(tap in into.state) (lead %s))]
         ::
@@ -297,9 +297,12 @@
       ==
     ::
     ++  ok
-      |=  [dap=dude =@p sent=@da kept=@da]
+      |=  [dap=dude place=(unit @p) sent=@da kept=(unit @da)]
       ^-  ^json
-      (pairs ~[agent/s/dap ship/(ship p) sent/(sect sent) kept/(sect kept)])
+      %-  pairs
+      :~  agent/s/dap       ship/(bindcast place ship)
+          sent/(sect sent)  kept/(bindcast kept sect)
+      ==
     --
   --
 --

--- a/urbit/desk.docket-0
+++ b/urbit/desk.docket-0
@@ -1,7 +1,7 @@
 :~  title+'Keep'
     info+'Back up your Urbit.'
     color+0x81.88c9
-    glob-http+['https://freedom-club.sfo2.digitaloceanspaces.com/glob-0vn2v8b.4fd2a.sk6t2.rpjs9.uhffv.glob' 0vn2v8b.4fd2a.sk6t2.rpjs9.uhffv]
+    glob-http+['https://freedom-club.sfo2.digitaloceanspaces.com/glob-0v6.9e37d.7gsfl.vi477.35scp.n6mml.glob' 0v6.9e37d.7gsfl.vi477.35scp.n6mml]
     base+'keep'
     version+[0 0 2]
     website+'https://dalten.org/'

--- a/urbit/desk.docket-0
+++ b/urbit/desk.docket-0
@@ -1,7 +1,7 @@
 :~  title+'Keep'
     info+'Back up your Urbit.'
     color+0x81.88c9
-    glob-http+['https://freedom-club.sfo2.digitaloceanspaces.com/glob-0v1.i10d7.3pf09.862r6.q70lv.dbdd1.glob' 0v1.i10d7.3pf09.862r6.q70lv.dbdd1]
+    glob-http+['https://freedom-club.sfo2.digitaloceanspaces.com/glob-0vn2v8b.4fd2a.sk6t2.rpjs9.uhffv.glob' 0vn2v8b.4fd2a.sk6t2.rpjs9.uhffv]
     base+'keep'
     version+[0 0 2]
     website+'https://dalten.org/'

--- a/urbit/keep/lib.hoon
+++ b/urbit/keep/lib.hoon
@@ -93,8 +93,9 @@
       upload-path
         /apps/keep/[dap.bowl]/upload
       start
-        :~  (poke-our:(pass /tell) %keep keep-agent+!>(`agent:poke`tell+dap.bowl))
-            (connect:(pass /eyre) `upload-path dap.bowl)
+        :~  (connect:(pass /eyre) `upload-path dap.bowl)
+            %+  poke-our:(pass /tell)  %keep
+            keep-agent+!>(`agent:poke`tell+dap.bowl)
         ==
   ::
   ++  on-poke
@@ -153,7 +154,8 @@
         %mend
       ?>  =(src.bowl our.bowl)
       =/  key  (scot %uv (sham eny.bowl))
-      :_  this(pending (~(put by pending) from.cmd %restore key))
+      =.  pending  (~(put by pending) from.cmd %restore key)
+      :_  this
       :~  (~(try-restore json state) from.cmd)
           %+  poke:(pass /grab/(scot %p from.cmd))  [from.cmd %keep]
           keep-agent+!>(`agent:poke`grab+dap.bowl^key)
@@ -343,9 +345,6 @@
   ++  saved
     |=  new=[(unit @p) @da]  (website-card 'saved' (json-da new))
   ::
-  ++  auto
-    |=  new=[(unit @p) (unit @dr)]  (website-card 'auto' (json-dr new))
-  ::
   ++  try-invite
     |=  =@p  (website-card 'pending' (json-pending [p %invite]))
   ::
@@ -358,25 +357,23 @@
   ++  malformed
     |=  [(unit @p) @da]  (website-card 'fail-restore' (json-da +<))
   ::
-  ++  success
-    |=  [=@p sent=@da kept=@da]
-    %+  website-card  'success'
-    (pairs ~[ship/(ship p) sent/(sect sent) kept/(sect kept)])
-  ::
   ++  website-card
     |=  [event=@t diff=^json]
     ^-  card
-    =;  json-state=^json
-      :*  %give  %fact  ~[/keep/website]  %json
-          !>((pairs ~[[%type s+event] [%diff diff] [%state json-state]]))
-      ==
+    %-  fact:agentio  :_  ~[/keep/website]
+    :-  %json  !>  ^-  ^json
+    =-  ~&  >>  emit/-  -
     %-  pairs
-    :~  :+  %pending
-          %a
-        %+  turn  ~(tap by pending.state)
-        |=  [=@p status=?(%invite %restore) *]
-        (json-pending p status)
-    ==
+    :~  [%type s+event]
+        [%diff diff]
+        :-  %state
+        %-  pairs
+        :~  :+  %pending
+              %a
+            %+  turn  ~(tap by pending.state)
+            |=  [=@p status=?(%invite %restore) *]
+            (json-pending p status)
+    ==  ==
   ::
   ++  json-da
     |=  [place=(unit @p) prev=@da]

--- a/urbit/keep/lib.hoon
+++ b/urbit/keep/lib.hoon
@@ -108,7 +108,7 @@
     ?.  ?=(?(%keep %handle-http-request) mark)  call-inner
     ?:  ?=(%handle-http-request mark)
       =/  req  !<([@ta inbound-request:eyre] vase)
-      ?.  =([~ 0] (find upload-path (rash url.request.+.req stap)))
+      ?.  =([~ 0] (biff (rush url.request.+.req stap) (cury find upload-path)))
         call-inner
       ?>  =(src.bowl our.bowl)
       =/  [res=(unit agent:gall) cards=(list card)]

--- a/urbit/keep/lib.hoon
+++ b/urbit/keep/lib.hoon
@@ -362,7 +362,6 @@
     ^-  card
     %-  fact:agentio  :_  ~[/keep/website]
     :-  %json  !>  ^-  ^json
-    =-  ~&  >>  emit/-  -
     %-  pairs
     :~  [%type s+event]
         [%diff diff]

--- a/urbit/keep/lib.hoon
+++ b/urbit/keep/lib.hoon
@@ -6,6 +6,7 @@
 ::  %-(agent:keep your-agent)
 ::
 ::
+/+  verb
 /=  default-agent  /keep/lib/default-agent
 /=  agentio        /keep/lib/agentio
 /=  multipart      /keep/lib/multipart
@@ -29,10 +30,10 @@
     %+  roll  (diff ~(tap by wex.old) ~(tap by wex.bowl))
     |:  *[[[=wire =ship *] *] caz=(list card) ag=_agent]
     =-  [(weld caz -.-) +.-]
-    ?-  res0=(mule |.((on-agent:ag(src.+< ship) wire %kick ~)))
-        [%& *]  p.res0
+    ?-  res=(mule |.((on-agent:ag(src.+< ship) wire %kick ~)))
+        [%& *]  p.res
         [%| *]
-      %+  fall  (mole |.((on-fail:ag %kick leaf/"closing subsciption" p.res0)))
+      %+  fall  (mole |.((on-fail:ag %kick leaf/"closing subsciption" p.res)))
       `ag
     ==
   ::
@@ -40,10 +41,10 @@
     %+  roll  (diff ~(tap by sup.old) ~(tap by sup.bowl))
     |:  *[[* =ship =path] caz=(list card) ag=_agent]
     =-  [(weld caz -.-) +.-]
-    ?-  res0=(mule |.((on-leave:ag(src.+< ship) path)))
-        [%& *]  p.res0
+    ?-  res=(mule |.((on-leave:ag(src.+< ship) path)))
+        [%& *]  p.res
         [%| *]
-      %+  fall  (mole |.((on-fail:ag %leave p.res0)))
+      %+  fall  (mole |.((on-fail:ag %leave p.res)))
       `ag
     ==
   ::
@@ -65,9 +66,6 @@
 ::
 +$  state-0
   $:  %0
-      live=_|
-      last=(map (unit ship) @da)
-      auto=(map (unit ship) @dr)
       pending=(map ship [?(%invite %restore) term])
   ==
 ::
@@ -77,6 +75,7 @@
   =|  state-0
   =*  state  -
   ::
+  %+  verb  &
   ^-  agent:gall
   |_  bowl:gall
   +*  this  .
@@ -91,11 +90,12 @@
       ag    ~(. agent dish)
       io    ~(. agentio bowl)
       pass  |=  =path  ~(. pass:io keep/path)
-      behn  |=  u=(unit ship)  behn/?~(u /put /ship/(scot %p u.u))
-      tell
-        (poke-our:(pass /tell) %keep keep-agent+!>(`agent:poke`tell+dap.bowl))
       upload-path
         /apps/keep/[dap.bowl]/upload
+      start
+        :~  (poke-our:(pass /tell) %keep keep-agent+!>(`agent:poke`tell+dap.bowl))
+            (connect:(pass /eyre) `upload-path dap.bowl)
+        ==
   ::
   ++  on-poke
     |=  [=mark =vase]
@@ -123,17 +123,17 @@
     =/  cmd  !<(wrap:poke vase)
     ?-  -.cmd
     ::  Back up your state once
-        %once
+        %send
       ?>  =(src.bowl our.bowl)
-      ::
       =/  paths
         ?~  to.cmd  ~
         %+  murn  ~(val by sup.bowl)
         |=  [=ship =path]
-        ?.  =(ship u.to.cmd)  ~
+        ?.  &(=(ship u.to.cmd) ?=([%keep %data *] path))
+          ~
         `path
       ::  Possible to back up now?
-      ?:  ?&(?=(^ to.cmd) ?=(~ paths))
+      ?:  &(?=(^ to.cmd) ?=(~ paths))
         ::  No. Initiate new connection.
         =/  key  (scot %uv (sham eny.bowl))
         =.  pending  (~(put by pending) u.to.cmd %invite key)
@@ -144,34 +144,11 @@
         ==
       ::  Yes. Give the fact or write to put and set new timers.
       =/  backup  [wex.dish sup.dish +:on-save:ag]
-      =/  freq  (~(get by auto) to.cmd)
-      =/  prev  (~(get by last) to.cmd)
-      =.  last  (~(put by last) to.cmd now.bowl)
-      ::
       :_  this
-      %-  catunits
-      :~  (bind (both `now.bowl freq) (cork add wait:(pass (behn to.cmd)))) :: set next
-          (bind (both prev freq) (cork add rest:(pass (behn to.cmd)))) :: unset old next
-          `(~(saved json state) to.cmd now.bowl)
-          ?~  to.cmd
-            `(drop our.bowl now.bowl dap.bowl backup)
-          `(fact:io noun+!>(backup) paths)
-      ==
-    ::  Set/unset repeating backups
-        %many
-      ?>  live
-      ?>  =(src.bowl our.bowl)
-      =/  freq  (~(get by auto) to.cmd)
-      =/  prev  (~(get by last) to.cmd)
-      =.  auto  (putunit auto to.cmd freq.cmd)
-      :_  this
-      %-  catunits
-      :~  (bind (both prev freq) (cork add rest:(pass (behn to.cmd)))) :: unset old next
-          `(~(auto json state) to.cmd freq.cmd)
-          ?^  new=(bind (both prev freq.cmd) (cork add wait:(pass (behn to.cmd))))
-            new :: set next later
-          (bind freq.cmd |=(* (wait:(pass (behn to.cmd)) now.bowl))) :: set next now
-      ==
+      :_  ~[(~(saved json state) to.cmd now.bowl)]
+      ?~  to.cmd
+        (drop our.bowl now.bowl dap.bowl backup)
+      (fact:io noun+!>(backup) paths)
     ::  Ask another ship for your state
         %mend
       ?>  =(src.bowl our.bowl)
@@ -192,50 +169,23 @@
       =^  cards  agent  u.res
       :_  this
       [(~(restored json state) `src.bowl now.bowl) cards]
-    ::  Turn wrapper on or off
-        %live
-      ?>  =(our.bowl src.bowl)
-      ?:  =(live live.cmd)  `this
-      =.  live  live.cmd
-      =?  auto  !live.cmd  ~
-      =?  last  !live.cmd  ~
-      :_  this
-      :-  ~(live json state)
-      ?:  live
-        ~[(connect:(pass /eyre) `upload-path dap.bowl)]
-      ~[(arvo:(pass /eyre) %e %disconnect `upload-path)]
-    ::  Successful backup
-        %okay
-      :_  this
-      ~[(~(success json state) src.bowl (~(got by last) `src.bowl) time.cmd)]
     ==
   ::
-  ++  on-peek
-    |=  =path
-    ^-  (unit (unit cage))
-    ~&  [%keep peek=path]
-    ?.  ?=([%x %keep %live ~] path)  (on-peek:ag path)
-    ``loob+!>(live)
+  ++  on-peek  on-peek:ag
   ::
   ++  on-init
     ^-  (quip card agent:gall)
     =^  cards  agent  on-init:ag
     :_  this
-    [tell cards]
+    (weld start cards)
   ::
-  ++  on-save
-    ?.  live  on-save:ag
-    !>([on-save:ag state])
+  ++  on-save  on-save:ag
   ::
   ++  on-load
     |=  old=vase
     ^-  (quip card agent:gall)
-    ?^  our=(mole |.(!<([vase _state] old)))
-      =^  their  state  u.our
-      =^  cards  agent  (on-load:ag their)
-      [[tell cards] this]
     =^  cards  agent  (on-load:ag old)
-    [[tell cards] this]
+    [(weld start cards) this]
   ::
   ++  on-leave
     |=  =path
@@ -262,7 +212,8 @@
       ~|  %didnt-ask
       ?>  =([%invite &3.path] (~(got by pending) src.bowl))
       =.  pending  (~(del by pending) src.bowl)
-      (on-poke(src.+< our.bowl) %keep !>(`wrap:poke`once+`src.bowl))
+      :_  this
+      ~[(poke-self:(pass /poke) keep/!>(`wrap:poke`send+`src.bowl))]
     ==
   ::
   ++  on-agent
@@ -282,20 +233,12 @@
       =^  cards  agent  (on-arvo:ag wire sign-arvo)
       [cards this]
     ::
-    ?+    +.wire  (on-arvo:def wire sign-arvo)
+    ?+    +.wire  (on-arvo:def wire sign-arvo)  ::TODO use ?.
         [%eyre ~]
       ?>  ?=([%eyre %bound *] sign-arvo)
       %.  `this
       ?:  accepted.sign-arvo  same
       (slog leaf+"keep-wrapper-fail -binding-eyre-for-import" ~)
-    ::
-        [%behn ^]
-      ?>  ?=([%behn %wake *] sign-arvo)
-      ?^  error.sign-arvo  ((slog u.error.sign-arvo) `this)
-      ?+  +>.wire  ((slog keep/on-arvo/invalid-wire=wire) `this)
-        [%put *]        (on-poke keep/!>(`wrap:poke`once/~))
-        [%ship term *]  (on-poke keep/!>(`wrap:poke`once/`(slav %p &4.wire)))
-      ==
     ==
   ::
   ++  on-fail
@@ -412,8 +355,6 @@
   ++  restored
     |=  new=[(unit @p) @da]  (website-card 'restored' (json-da new))
   ::
-  ++  live  (website-card 'active' b+live.state)
-  ::
   ++  malformed
     |=  [(unit @p) @da]  (website-card 'fail-restore' (json-da +<))
   ::
@@ -430,13 +371,7 @@
           !>((pairs ~[[%type s+event] [%diff diff] [%state json-state]]))
       ==
     %-  pairs
-    :~  [%live b+live.state]
-        [%saved a+(turn ~(tap by last.state) json-da)]
-    ::
-        :-  %auto
-        a+(turn ~(tap by auto.state) |=([=(unit @p) =@dr] (json-dr unit `dr)))
-    ::
-        :+  %pending
+    :~  :+  %pending
           %a
         %+  turn  ~(tap by pending.state)
         |=  [=@p status=?(%invite %restore) *]

--- a/urbit/keep/sur/keep.hoon
+++ b/urbit/keep/sur/keep.hoon
@@ -12,15 +12,15 @@
         [%able (each ship ship)]
         [%wyte on=?]
         [%copy to=desk]
+        [%once dap=dude to=(unit ship)]
+        [%many dap=dude to=(unit ship) freq=(unit @dr)] :: Repeat backup
+        [%okay dap=dude time=@da]
     ==
   ::                                           :: To the wrapper.
   +$  wrap                                     ::
-    $%  [%once to=(unit ship)]                 :: Backup to a ship or the put dir
-        [%many to=(unit ship) freq=(unit @dr)] :: Repeat backup
+    $%  [%send to=(unit ship)]                 :: Backup to a ship or the put dir
         [%mend from=ship]                      :: Initiate recovery
         [%data data=noun key=term]             :: Old state and secret (internal only)
-        [%live live=?]                         :: (De)activate. Deact before uninstall!
-        [%okay time=@da]
     ==
   --
 --

--- a/urbit/lib/mip.hoon
+++ b/urbit/lib/mip.hoon
@@ -1,0 +1,60 @@
+|%
+++  mip                                                 ::  map of maps
+  |$  [kex key value]
+  (map kex (map key value))
+::
+++  bi                                                  ::  mip engine
+  =|  a=(map * (map))
+  |@
+  ++  del
+    |*  [b=* c=*]
+    =+  d=(~(gut by a) b ~)
+    =+  e=(~(del by d) c)
+    ?~  e
+      (~(del by a) b)
+    (~(put by a) b e)
+  ::
+  ++  get
+    |*  [b=* c=*]
+    =>  .(b `_?>(?=(^ a) p.n.a)`b, c `_?>(?=(^ a) ?>(?=(^ q.n.a) p.n.q.n.a))`c)
+    ^-  (unit _?>(?=(^ a) ?>(?=(^ q.n.a) q.n.q.n.a)))
+    (~(get by (~(gut by a) b ~)) c)
+  ::
+  ++  got
+    |*  [b=* c=*]
+    (need (get b c))
+  ::
+  ++  gut
+    |*  [b=* c=* d=*]
+    (~(gut by (~(gut by a) b ~)) c d)
+  ::
+  ++  has
+    |*  [b=* c=*]
+    !=(~ (get b c))
+  ::
+  ++  key
+    |*  b=*
+    ~(key by (~(gut by a) b ~))
+  ::
+  ++  put
+    |*  [b=* c=* d=*]
+    %+  ~(put by a)  b
+    %.  [c d]
+    %~  put  by
+    (~(gut by a) b ~)
+  ::
+  ++  tup
+    |*  [b=* c=* d=(unit *)]
+    ?~  d  (del b c)
+    (put b c u.d)
+  ::
+  ++  tap
+    ::NOTE  naive turn-based implementation find-errors ):
+    =<  $
+    =+  b=`_?>(?=(^ a) *(list [x=_p.n.a _?>(?=(^ q.n.a) [y=p v=q]:n.q.n.a)]))`~
+    |.  ^+  b
+    ?~  a
+      b
+    $(a r.a, b (welp (turn ~(tap by q.n.a) (lead p.n.a)) $(a l.a)))
+  --
+--

--- a/urbit/mar/keep.hoon
+++ b/urbit/mar/keep.hoon
@@ -14,15 +14,9 @@
   |%
   ++  noun  wrap:poke
   ++  json
-    %+  corl  $<(%data wrap:poke)
+    %+  corl  wrap:poke
     =,  dejs:format
-    %-  of
-    :~
-      [%once (mu (se %p))]
-      [%mend (se %p)]
-      [%live bo]
-      :-  %many
-      (ot ~[[%to (mu (se %p))] [%freq (cu (lift (cury mul ~s1)) (mu ni))]])
+    (ot mend/(se %p))
     ==
   --
 --

--- a/urbit/mar/keep/agent.hoon
+++ b/urbit/mar/keep/agent.hoon
@@ -20,8 +20,8 @@
     :~  [%able (ot ~[able/bo ship/(se %p)])]
         [%wyte bo]
         [%copy so]
-        [%once (ot ~[from/so to/(mu (se %p))]]
-        %-  %many
+        [%once (ot ~[from/so to/(mu (se %p))])]
+        :-  %many
         (ot ~[from/so to/(mu (se %p)) freq/(cu (lift (cury mul ~s1)) (mu ni))])
     ==
   --

--- a/urbit/mar/keep/agent.hoon
+++ b/urbit/mar/keep/agent.hoon
@@ -14,13 +14,15 @@
   |%
   ++  noun  agent:poke
   ++  json
-    %+  corl  $<(?(%init %grab) agent:poke)
+    %+  corl  agent:poke
     =,  dejs:format
     %-  of
-    :~  [%tell (ot ~[['dap' so] ['live' bo]])]
-        [%able (ot ~[able+bo ship+(se %p)])]
+    :~  [%able (ot ~[able/bo ship/(se %p)])]
         [%wyte bo]
         [%copy so]
+        [%once (ot ~[from/so to/(mu (se %p))]]
+        %-  %many
+        (ot ~[from/so to/(mu (se %p)) freq/(cu (lift (cury mul ~s1)) (mu ni))])
     ==
   --
 --


### PR DESCRIPTION
- [x] Change architecture
- [x] Test architecture
- [x] Emit proper JSON
- [x] Test JSON emissions
- [x] Parse JSON commands
- [x] Test JSON commands
- [x] Documentation

## Pokes
- `%live` is completely deprecated.
- `%once` and `%many` have moved from the wrapper to the agent, and include the agent name as their first argument:
  ```hoon
  [%once from=dude to=(unit ship)]
  [%many from=dude to=(unit ship) freq=(unit @dr)]
  ```
  ```json
  "once": { "from": "simple", "to": "~sampel" }
  "many": { "from": "simple", "to": "~palnet", "freq": 555 }
  ```
  Note that both of these now require the `%keep-agent` mark, just as all other commands sent to the agent.
- No other pokes have changed. Notably, `%mend` is still sent to the wrapper.

## State/diff
### Wrapper
- The wrapper no longer emits `saved` or `auto` as part of its state, nor the diffs associated with them.
- The wrapper still emits `pending` and its associated diffs.
- The wrapper still emits events when a backup is sent to another ship or to put, as well as when a restoration was successful or unsuccessful.

### Agent
- The agent now emits `saved` and `auto` as part of its state whenever these change. The diffs and the state objects themselves both look like this:
  ```json
  { "agent": "simple", "ship": "~sampel", "freq": 555 }
  { "agent": "simple", "ship": "~sampel", "time": 5528347 }
  ```
  (Note the difference between `freq` and `time`, as before.)
 - If the agent is unable to poke the wrapper (presumably because a previously wrapped agent was unwrapped), it will emit a `no-save` diff instead of a `saved` diff. These include the exact same components but the state won't have changed in the former.